### PR TITLE
fix: translations

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -182,6 +182,7 @@
                 {% set configured_light_theme = 'goyo-light' %}
             {% endif %}
             window.GOYO_CONFIG = {
+                ...window.GOYO_CONFIG,
                 defaultThemeDark: "{{ configured_dark_theme }}",
                 defaultThemeLight: "{{ configured_light_theme }}",
             };

--- a/templates/macros/utils.html
+++ b/templates/macros/utils.html
@@ -1,26 +1,13 @@
 {% macro trans_or_default(key, default, lang, config, config_file=false) -%}
-    {%- set result = default -%}
-    {%- set found = false -%}
+    {%- set effective_lang = lang | default(value=config.default_language | default(value="en")) -%}
 
-    {%- if lang -%}
-        {%- set effective_lang = lang -%}
-    {%- elif config.default_language -%}
-        {%- set effective_lang = config.default_language -%}
+    {# 1- Zola i18n (languages.xx.translations) #}
+    {%- set text = trans(key=key, lang=effective_lang) -%}
+    {# if translation exists returns it otherwise it returns the key itself #}
+    {%- if text != key -%}
+        {{ text }}
     {%- else -%}
-        {%- set effective_lang = "en" -%}
-    {%- endif -%}
-
-    {# Try config object first (fast, for non-default languages) #}
-    {%- if effective_lang != config.default_language -%}
-         {%- if config.languages and config.languages[effective_lang] and config.languages[effective_lang].translations and config.languages[effective_lang].translations[key] -%}
-             {%- set_global result = config.languages[effective_lang].translations[key] -%}
-             {%- set_global found = true -%}
-         {%- endif -%}
-    {%- endif -%}
-
-    {# If not found in specific language, try loading config files for default language translations #}
-    {# Use provided config_file if available to avoid redundant loads #}
-    {%- if not found -%}
+        {# 2- Theme fallback: root [translations] loaded from config file (often default language) #}
         {%- set loaded_config = config_file -%}
         {%- if not loaded_config -%}
             {%- set loaded_config = load_data(path="/config.toml", format="toml", required=false) -%}
@@ -32,13 +19,10 @@
             {%- endif -%}
         {%- endif -%}
 
-        {%- if loaded_config -%}
-             {# Check default language translations in loaded data #}
-             {%- if loaded_config.translations and loaded_config.translations[key] -%}
-                 {%- set_global result = loaded_config.translations[key] -%}
-             {%- endif -%}
+        {%- if loaded_config and loaded_config.translations and loaded_config.translations[key] -%}
+            {{ loaded_config.translations[key] }}
+        {%- else -%}
+            {{ default }}
         {%- endif -%}
     {%- endif -%}
-
-    {{ result }}
 {%- endmacro %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -239,7 +239,7 @@
                     <svg class="w-5 h-5 transition-transform group-hover:-translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path>
                     </svg>
-                    <span class="nav-button-label">Previous</span>
+                    <span class="nav-button-label">{{ utils::trans_or_default(key="back_to", default="Back to", lang=lang, config=config, config_file=config_file) }}</span>
                 </div>
                 <div class="nav-button-title">{{ page.smaller.title }}</div>
             </div>


### PR DESCRIPTION
Hi again ^^

This is a fix for the translation feature, it wasn't working anymore.

I tried to keep your logic in `utils.html` macro, I let you check if I missed something.
The original problem was trying to access `effective_lang` this way: `config.languages[effective_lang]` but it never returns anything so when switching to Korean it always remained in english

For the "Copy/copied/..." buttons, the translation wasn't working anymore too. The problem was the second call of 'window.GOYO_CONFIG' in `index.html` that was reassigning a new value.

