### PR TITLE
Use configured theme names for first-load fallback in index.html

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -110,8 +110,11 @@
               window.defaultColorset = "{{ js_theme_colorset }}";
               window.darkBrightness = "{{ js_dark_brightness }}";
               window.lightBrightness = "{{ js_light_brightness }}";
-              window.themeMap = { "dark": "goyo-dark", "light": "goyo-light" };
-              window.fallbackTheme = window.themeMap[window.defaultColorset] || "goyo-dark";
+              window.themeMap = {
+                  "dark": (window.themeConfig && window.themeConfig.darkTheme) || "goyo-dark",
+                  "light": (window.themeConfig && window.themeConfig.lightTheme) || "goyo-light"
+              };
+              window.fallbackTheme = window.themeMap[window.defaultColorset] || (window.themeConfig && window.themeConfig.darkTheme) || "goyo-dark";
 
               // Theme mapping - maps user-friendly names to actual DaisyUI theme names
               var themeMapping = { "goyo-dark": "night", "goyo-light": "lofi" };

--- a/templates/index.html
+++ b/templates/index.html
@@ -124,7 +124,7 @@
               // Initialize and run Mermaid only when loaded
               window.initMermaid = function() {
                 var mermaidTheme = "dark";
-                if(currentUserTheme == "goyo-light") {
+                if(currentUserTheme == window.themeMap["light"]) {
                   mermaidTheme = "light";
                 }
 


### PR DESCRIPTION
Just for transparency, this PR was created with the assistance of AI (specifically Anthropic's Claude).

I'm using your (wonderful) theme for a docs site for a personal project of mine, and I've created some custom daisyUI themes for the site so it's thematic with the project. However, I noticed an issue where, when a device visited the site for the first time, it would show a basic default light theme. Clicking the theme toggle in the top left would toggle the site to the correct theme, and thereafter it would correctly work like normal.

After digging into the issue with the help of Claude, it looks like the issue lies in `templates/index.html`, where the `window.themeMap` variable is hardcoded in and immediately sets `window.fallbackTheme` based on itself. Once the correct theme is in `localStorage`, it correctly reads from there afterwards, but just that first time can cause the issue.

I did test this fix, both under the steps specified in the contribution guide and on my own site, and it seems to fix the issue, so I believe this PR should be good. However, you know the code far better than I do, so I welcome any questions, comments, concerns, or other pushback.